### PR TITLE
 Fixing toast notification for Unsuccessful attempt of sending login link i.e when email is empty

### DIFF
--- a/client/src/components/LoginDialog.jsx
+++ b/client/src/components/LoginDialog.jsx
@@ -41,6 +41,19 @@ const LoginDialog = ({ isOpen, onClose, createAccount = false }) => {
     }
   };
 
+  const handleLoginLink = async (e) => {
+    e.preventDefault();
+    const result = await sendLoginLink(email);
+    if (result.success) {
+      toast.success("Login link sent successfully, check your email.");
+    } else {
+      toast.error("Unable to proceed", {
+        description: result.message,
+      });
+    }
+  };
+  
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-[425px] text-white bg-black">
@@ -78,13 +91,7 @@ const LoginDialog = ({ isOpen, onClose, createAccount = false }) => {
               <Label htmlFor="password">Password</Label>
               <span
                 className="text-sm text-gray-400 hover:text-white cursor-pointer"
-                onClick={() => {
-                  sendLoginLink(email).then(() => {
-                    toast.success(
-                      "Login link sent successfully, check your email."
-                    );
-                  });
-                }}
+                onClick={handleLoginLink}
               >
                 {isSendingLoginLink ? "Sending..." : "Email me a login link!"}
               </span>


### PR DESCRIPTION
- When the email field is empty, clicking "Email me a login link" in the loginDialog still shows a success toast in the current codebase.
-  Screenshot of issue <br>
 ![image](https://github.com/user-attachments/assets/bd70ebde-78f1-4ea6-8cfd-5f0786ff1bd1)

- After Fixing the issue. <br>

![image](https://github.com/user-attachments/assets/c8b54cfd-bb99-4fe4-abb2-4c2940f04325)

fixes issue #18 