### PR TITLE
Enable locking available ships  - added reduce credit at start of startProject event and in catch handling revert the available ships

### DIFF
--- a/server/controllers/onboardingToolController.js
+++ b/server/controllers/onboardingToolController.js
@@ -4,13 +4,13 @@ const searchService = require("../services/searchService");
 const { toKebabCase } = require("../utils/file");
 const {
   insertShip,
-  getUserProfile,
-  updateUserProfile,
+  // getUserProfile,
+  // updateUserProfile,
   updateConversation,
 } = require("../services/dbService");
 const { TOOLS } = require("../config/tools");
 
-const { nanoid } = require('nanoid');
+const { nanoid } = require("nanoid");
 
 const generateProjectFolderName = (projectName) => {
   return toKebabCase(projectName) + "-" + nanoid(8);
@@ -145,12 +145,14 @@ async function handleOnboardingToolUse({
     };
     const { id } = await insertShip(ship);
     console.log("Inserted ship", id);
-    if (mode === 'paid') {
-      const profile = await getUserProfile(userId);
-      const { available_ships } = profile; // current
-      const profilePayload = { available_ships: available_ships - 1 }; // updated
-      await updateUserProfile(userId, profilePayload);
-    }
+
+    // removing deduct available ships from here.
+    // if (mode === 'paid') {
+    //   const profile = await getUserProfile(userId);
+    //   const { available_ships } = profile; // current
+    //   const profilePayload = { available_ships: available_ships - 1 }; // updated
+    //   await updateUserProfile(userId, profilePayload);
+    // }
     const convPayload = {
       ship_id: id,
       tokens_used: client.tokensUsed,

--- a/server/services/onboadingService.js
+++ b/server/services/onboadingService.js
@@ -13,7 +13,11 @@ const {
   handleOnboardingToolUse,
 } = require("../controllers/onboardingToolController");
 const { AnthropicService } = require("../services/anthropicService");
-const { getUserProfile, insertMessage } = require("../services/dbService");
+const {
+  getUserProfile,
+  insertMessage,
+  updateUserProfile,
+} = require("../services/dbService");
 const { SHIP_TYPES, DEFAULT_MESSAGES } = require("./constants");
 
 async function processConversation({
@@ -52,7 +56,6 @@ async function processConversation({
         tools.push(searchTool);
         messages = [{ role: "user", content: message }];
       }
-
     }
 
     try {
@@ -188,7 +191,14 @@ function handleOnboardingSocketEvents(io) {
       };
 
       abortController = new AbortController();
+      const mode = client.isCustomKey ? "self-key" : "paid";
       try {
+        if (mode === "paid") {
+          const profile = await getUserProfile(userId);
+          const { available_ships } = profile; // current
+          const profilePayload = { available_ships: available_ships - 1 }; // updated
+          await updateUserProfile(userId, profilePayload);
+        }
         await processConversation({
           client,
           sendEvent,
@@ -206,6 +216,14 @@ function handleOnboardingSocketEvents(io) {
           sendEvent("creationAborted", {
             message: "Website creation was aborted",
           });
+
+          // revert available ships in case of paid mode
+          if (mode === "paid") {
+            const profile = await getUserProfile(userId);
+            const { available_ships } = profile;
+            const profilePayload = { available_ships: available_ships + 1 }; // updated
+            await updateUserProfile(userId, profilePayload);
+          }
         } else {
           console.error("Error in processConversation:", error);
         }


### PR DESCRIPTION
Closes #14 

- Added reduce available ship in `startProject` event.
- Added a catch handling to revert the available ships in case of any error.
