### PR TITLE
Handle client side routing on server - added a route at the end of all server routes to serve react routes.

### DIFF
--- a/client/src/pages/Edit/index.jsx
+++ b/client/src/pages/Edit/index.jsx
@@ -27,7 +27,7 @@ import { Badge } from "@/components/ui/badge";
 
 const Edit = () => {
   const navigate = useNavigate();
-  const { user } = useContext(AuthContext);
+  const { user, userLoading } = useContext(AuthContext);
   const { shipId } = useParams();
 
   const {
@@ -50,13 +50,13 @@ const Edit = () => {
   const [currentDevice, setCurrentDevice] = useState(DEVICE_FRAMES[0]);
 
   useEffect(() => {
-    if (!user || !shipId) {
+    if (!userLoading && (!user || !shipId)) {
       navigate("/");
     } else {
       // Call handleFileSelect with '$shipId/index.html' when the component mounts
       handleFileSelect({ path: `${shipId}/index.html`, name: "index.html" });
     }
-  }, [user, shipId, navigate]);
+  }, [user, shipId, navigate, userLoading]);
 
   const handleFileSelect = async (file) => {
     setSelectedFile(file);

--- a/server.js
+++ b/server.js
@@ -53,7 +53,9 @@ app.get("/ship", (req, res) => {
 app.get("/taaft.txt", async (req, res) => {
   res.setHeader("Content-Type", "text/plain");
   res.setHeader("Content-Disposition", "attachment; filename=taaft.txt");
-  res.send("taaft-verification-code-8e81f753e37549d83c99e93fc5339c3093359943ba88ba5db9c5822e373366f4");
+  res.send(
+    "taaft-verification-code-8e81f753e37549d83c99e93fc5339c3093359943ba88ba5db9c5822e373366f4"
+  );
 });
 
 app.post("/payment-webhook", express.json(), async (req, res) => {
@@ -221,8 +223,6 @@ app.get("/:websiteId", async (req, res) => {
   }
 });
 
-
-
 app.get("/download/:slug", async (req, res) => {
   const slug = req.params.slug;
   const folderPath = `websites/${slug}`;
@@ -286,6 +286,11 @@ app.use("/site/:siteId", async (req, res, next) => {
     }
     res.status(500).send("An error occurred");
   }
+});
+
+// Catch-all route after server routes and give to react router
+app.get("*", (req, res) => {
+  res.sendFile(path.join(__dirname, "public", "index.html"));
 });
 
 handleOnboardingSocketEvents(io);


### PR DESCRIPTION
# Changes
- Added a catch all route in `server.js` file at the end of all server routes to give unmatched routes to react router to handle and serve.
- Added userLoading condition in Edit component because on page refreshing initial value of user was null in auth context and the useEffect hook was redirecting to `/` in case of `!user`.