### PR TITLE
Fix: URL Redirection and 404 Error on Code Editor Reload

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,6 +40,13 @@ app.use(express.json());
 app.use(express.static("websites"));
 app.use(express.static("public"));
 app.use(cors());
+app.use((req, res, next) => {
+  if (req.path !== '/' && !req.path.endsWith('/')) {
+    res.redirect(301, `${req.path}/`);
+  } else {
+    next();
+  }
+});
 
 app.get("/all", async (req, res) => {
   res.sendFile(path.join(__dirname, "public", "all.html"));
@@ -193,6 +200,10 @@ async function serializeDom(filePath, baseUrl) {
 
   return dom.serialize();
 }
+
+app.get('/project/*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
 
 app.get("/:websiteId", async (req, res) => {
   const websiteId = req.params.websiteId;


### PR DESCRIPTION
Implemented URL redirection to ensure non-trailing slash URLs automatically redirect to their trailing slash counterparts, and resolved the 404 error on reloading the code editor screen.

Resolves: #12 